### PR TITLE
Update base images to specific versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# always build this using the latest stable release
-FROM rust:latest as build
+FROM rust:1.40.0 as build
 
 RUN mkdir -p /rust-test-runner/src
 WORKDIR /rust-test-runner
@@ -16,7 +15,8 @@ COPY src/* src/
 RUN cargo build --release
 
 # As of Dec 2019, we need to use the nightly toolchain to get JSON test output
-FROM rustlang/rust:nightly AS test
+# FROM rustlang/rust:nightly AS test
+FROM rustlang/rust:b4f4f4589b1108f38f83a91e009761a182bdb4e4f12f03e508352f5fb9154910
 ENV wd /opt/test-runner
 RUN mkdir -p ${wd}/bin
 WORKDIR ${wd}


### PR DESCRIPTION
Hi @coriolinus,

Please feel free to think about a different way of achieving this... but I can't think of one right now.

To ensure that all builds are repeatable, I think we need to be explicit about versions of base images. To this end, I've tried to replace the docker tags 'nightly' and 'latest' with more stable tags.

The first change I've made is, I think, reasonable. We'll want a specific git-commit to relate to a specific rust language.

It's the versioning of the second base image that frustrates me. The nightly builds have no other versioned tagging, so the only way of achieving stability is to be precise with the SHA digest (which has poor readability). I wondered whether there's another docker image we could use here, but I don't know enough about the Rust ecosystem to understand.

Appreciate your insights.