### PR TITLE
Configure the env-vars that docker implicitly sets

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+export RUSTUP_HOME=/usr/local/rustup
+export CARGO_HOME=/usr/local/cargo
+export PATH=/usr/local/cargo/bin:$PATH
+
 slug="$1"
 solution_path="$2"
 output_path="$3"


### PR DESCRIPTION
Hi @coriolinus,

Hopefully this will be a reasonably non-controversial change. We've had to do this for a few other tracks.

Although we're building the container images from Dockerfiles, we're not invoking them through Docker (instead we're exporting them as OCI containers and invoking with runc). As a result, the implicit runtime config that gets set via the Dockerfile chain is missing from our invocation environment,

Specifically, we need the ENV directives that were set from the base image Dockerfile, see

https://github.com/rust-lang/docker-rust/blob/3898d19194231639f1afc3096bd04702eaf555e7/1.40.0/buster/Dockerfile#L3