### PR TITLE
remove backtrace from test failures (and other panics)

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -37,9 +37,7 @@ else
     echo "WARNING: student did not upload Cargo.lock. This may cause build errors." | tee -a "$output_path/results.out"
 fi
 
-RUST_BACKTRACE=1 \
-RUST_TEST_TASKS=1 \
-    cargo +nightly test \
+cargo +nightly test \
     --offline \
     -- \
     -Z unstable-options \


### PR DESCRIPTION
Closes #7

Also remove restriction to single core, which is no longer required
now that we no longer have to return only the first failure. This
enables automatic test parallelism.