### PR TITLE
[Rust] Retrieve stderr to display error message

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -37,6 +37,7 @@ else
     echo "WARNING: student did not upload Cargo.lock. This may cause build errors." | tee -a "$output_path/results.out"
 fi
 
+set +e
 cargo +nightly test \
     --offline \
     -- \
@@ -44,7 +45,8 @@ cargo +nightly test \
     --include-ignored \
     --format json \
     2> >(tee -a "$output_path"/results.out >&2) \
-    |\
-        /opt/test-runner/bin/transform-output \
+    > "$output_path"/results.cargo
+
+/opt/test-runner/bin/transform-output "$output_path"/results.cargo "$output_path"/results.out \
         > "$output_path"/results.json
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,14 @@ use cargo_test as ct;
 use output as o;
 
 /// convert a stream of test events into a single test result
-pub fn convert<I, E>(events: I) -> o::Output
+pub fn convert<I, E>(events: I, stderr: String) -> o::Output
 where
     I: Iterator<Item = Result<ct::TestEvent, E>>,
     E: serde::de::Error + std::fmt::Display,
 {
     let mut out = o::Output {
         status: o::Status::Error,
-        message: Some("no tests detected; probable build failure".into()),
+        message: Some(stderr),
         tests: Vec::new(),
     };
     for (idx, event) in events.enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,14 @@ use transform_output::cargo_test::TestEvent;
 use transform_output::convert;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let stdin = std::io::stdin();
+    let args: Vec<String> = std::env::args().collect();
+    let cargo_out = std::fs::read_to_string(&args[1])?;
+    let stderr = std::fs::read_to_string(&args[2])?;
 
-    let out = convert(serde_json::Deserializer::from_reader(stdin.lock()).into_iter::<TestEvent>());
+    let out = convert(
+        serde_json::Deserializer::from_str(cargo_out.as_str()).into_iter::<TestEvent>(),
+        stderr,
+    );
 
     let stdout = std::io::stdout();
     serde_json::to_writer_pretty(stdout.lock(), &out)?;


### PR DESCRIPTION
It seems to correctly report cargo stderr in case no tests are run.
To do this, I've split the `cargo test` command in 2. First run cargo test and redirect stdout to results.cargo and stderr to results.out. Then run `transform-output` with both files as arguments. I've adjusted the main rust program to read those files instead of stdin.

One note, I'm not sure why errors are reported in double.