### PR TITLE
Use latest cargo-local-registry (from git)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ COPY bin/generate-registry.sh ${wd}/bin/
 # download jq
 RUN curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
   && chmod +x /usr/local/bin/jq
-# download cargo-local-registry
-RUN curl -L -o clr.tar.gz https://github.com/ChrisGreenaway/cargo-local-registry/releases/download/0.2.1/cargo-local-registry-0.2.1-x86_64-unknown-linux-musl.tar.gz \
-  && tar xvzf clr.tar.gz && chmod +x cargo-local-registry && mv cargo-local-registry /usr/local/cargo/bin
+# build cargo-local-registry
+RUN cargo install --git https://github.com/ChrisGreenaway/cargo-local-registry.git
 # download popular crates to local registry
 WORKDIR /local-registry
 COPY local-registry/* ./

--- a/local-registry/Cargo.toml
+++ b/local-registry/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dummy_package"
 version="0.1.0"
+edition = "2021"
 
 [lib]
 path = "dummy.rs"


### PR DESCRIPTION
This fixes #34.

Make sure to pull `rust:latest` if it's not compiling locally (build needs cargo >= 1.56).

Sorry for the long resolution time, I had to resolve a few issues related to cargo-local-registry.
In this PR, we're building cargo-local-registry from its git source instead of pulling a binary release.
I'll update the Dockerfile once a binary is available to shorten build time.

I've made a test with the gigasecond exercise and it worked properly.