### PR TITLE
Add check and warning for missing `Cargo.toml`

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -28,7 +28,9 @@ if [ -z "$slug" ] || [ -z "$solution_path" ]; then
 fi
 
 cd "$solution_path"
-if [ ! -e Cargo.lock ]; then
+if [ ! -e Cargo.toml ]; then
+    echo "WARNING: student did not upload Cargo.toml. This may cause build errors." | tee -a "$output_path/results.out"
+elif [ ! -e Cargo.lock ]; then
     echo "WARNING: student did not upload Cargo.lock. This may cause build errors." | tee -a "$output_path/results.out"
 fi
 


### PR DESCRIPTION
As per issue #45 when `Cargo.toml` was not submitted by the student via the CLI and that caused a build error the test runner would give a warning about `Cargo.lock` not being attached which was not the cause of the error.