### PR TITLE
Correctly handle test timeouts (#54)

### DIFF
--- a/tests/example-timeout/Cargo.toml
+++ b/tests/example-timeout/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "example_timeout"
+version = "0.1.0"
+edition = "2021"

--- a/tests/example-timeout/expected_results.json
+++ b/tests/example-timeout/expected_results.json
@@ -1,0 +1,5 @@
+{
+  "version": 2,
+  "status": "error",
+  "message": "One of the tests timed out"
+}

--- a/tests/example-timeout/src/lib.rs
+++ b/tests/example-timeout/src/lib.rs
@@ -1,0 +1,6 @@
+pub fn do_something_forever() -> u8 {
+    loop {
+        println!("Hello, world!");
+    }
+    0
+}

--- a/tests/example-timeout/tests/timeout.rs
+++ b/tests/example-timeout/tests/timeout.rs
@@ -1,0 +1,6 @@
+use example_timeout::do_something_forever;
+
+#[test]
+fn test_infinite_loop() {
+    assert_eq!(0, do_something_forever());
+}


### PR DESCRIPTION
This PR fixes #54. The actual issue is not the output size; The runner currently does not support test timeouts. 

Currently, the rust test suite itself does not support setting time limits to abort a test that runs for too long (see rust-lang/rfcs#2798). 

There's an option `--ensure-time`, but it only controls the time threshold to mark a test failed (generates event like `{ "type": "test", "name": "tests::test_empty_a", "event": "failed", "exec_time": 7.000362262, "reason": "time limit exceeded" }`) and does not abort the test itself. 

So I see three ways of dealing with badly written code:

* wait for cargo to abort the hanging test after 120 secs. In this case, it emits timeout event like this: `{ "type": "test", "event": "timeout", "name": "test_empty" }` that could be parsed with the transformer. The downside is that for two minutes the test runner is going to be blocked. Not sure how bad it is for excercism, but generally blocked workers are no good.  :smile: 
* implement a custom test harness with support for test timeouts. While rust supports this, it looks to me like a very labor-intensive way to solve the problem.
* use an external utility to abort the test runner after some time. 

It seems to me, that the latter is currently the best way to solve the issue. I've taken the inspiration from the [rust playground](https://github.com/integer32llc/rust-playground/blob/master/compiler/base/entrypoint.sh) and changed the code to return `{status: "error", message:"Tests timed out"}` if the test suite does not finish after 5 sec.

Given the speed of rust, a timeout of 5 seconds seems reasonable to me, but please let me know if some shorter/longer fits better.

