### PR TITLE
Exit early in docker scripts

### DIFF
--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -e
+
 # Synopsis:
 # Run the test runner on a solution using the test runner Docker image.
 # The test runner Docker image is built automatically.

--- a/bin/run-tests-in-docker.sh
+++ b/bin/run-tests-in-docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -e
+
 # Synopsis:
 # Test the test runner Docker image by running it against a predefined set of 
 # solutions with an expected output.


### PR DESCRIPTION
This PR adds `set -e` to the `./bin/run-in-docker.sh` and `./bin/run-tests-in-docker.sh` scripts, to ensure that when building the Docker image fails, the entire script fails.
Without this change, the scripts would happily continue and Docker would download the latest version from Docker hub and things would _look_ like they're fine.
This was especially bad as we're using `./bin/run-tests-in-docker.sh` in our CI workflow.
