### PR TITLE
Fix dependabot config again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,5 @@ updates:
       all:
         patterns:
          - "*"
-    versioning-strategy: 'increase'
     labels:
       - 'x:rep/tiny'


### PR DESCRIPTION
Sorry about the spam. [These errors](https://github.com/exercism/rust-test-runner/runs/15237255545) are being drip-fed to us and apparently there's no good way to check a dependabot config locally.

Cargo only supports the strategies `auto` and `lockfile-only`.
The default `auto` is best for us.
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy