### PR TITLE
Use sccache to improve build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.71.0 as build
 ARG JQ_VERSION=1.6
 ARG JQ_URL=https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64
 
-ARG SC_VERSION=v0.2.15
+ARG SC_VERSION=v0.5.4
 ARG SC_URL=https://github.com/mozilla/sccache/releases/download/${SC_VERSION}/sccache-${SC_VERSION}-x86_64-unknown-linux-musl.tar.gz
 
 ENV SCCACHE_DIR=/opt/compilation-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ RUN cargo generate-lockfile && cargo local-registry --sync Cargo.lock .
 
 # populate compilation cache
 RUN cargo build
+# but remove large target folder
+RUN cargo clean
 
 # As of Dec 2019, we need to use the nightly toolchain to get JSON test output
 # tracking issue: https://github.com/rust-lang/rust/issues/49359


### PR DESCRIPTION
closes #35 

This is mostly a cherry-pick of #42, thanks @dhovart!

The compilation cache takes up 420 MB, taking the whole image from ~930 MB to ~1.4 GB. I will make an attempt to trim the list of available crates more aggressively (at a higher risk of breaking peoples solutions) to see what that does to the image size. It may well be the size is dominated by a couple crates and removing small obscure ones won't change much.

I also haven't measured the actual speed improvement yet. This is important data to make sure we're making a good trade off (image size vs testing speed).