### PR TITLE
Bump rust to 1.80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # always build this using the latest stable release
-FROM rust:1.74.1 as build
+FROM rust:1.80.0 as build
 
 
 ARG JQ_VERSION=1.6
@@ -41,7 +41,7 @@ RUN cargo generate-lockfile && cargo local-registry --sync Cargo.lock .
 # version tag with a nightly one, pinned to a specific date.
 
 # official Dockerfile source: 
-# https://github.com/rust-lang/docker-rust/blob/master/1.74.1/bookworm/slim/Dockerfile
+# https://github.com/rust-lang/docker-rust/blob/master/1.80.0/bookworm/slim/Dockerfile
 
 ################ start-copy-pasta ################
 
@@ -50,7 +50,7 @@ FROM debian:bookworm-slim
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly-2023-12-12
+    RUST_VERSION=nightly-2024-08-02
 #                ~~~~~~~~^~~~~~~~~~
 #                 pin version here
 
@@ -64,13 +64,15 @@ RUN set -eux; \
         ; \
     dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db' ;; \
-        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='f21c44b01678c645d8fbba1e55e4180a01ac5af2d38bcbd14aa665e0d96ed69a' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800' ;; \
-        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='e7b0f47557c1afcd86939b118cbcf7fb95a5d1d917bdd355157b63ca00fc4333' ;; \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='3c4114923305f1cd3b96ce3454e9e549ad4aa7c07c03aec73d1a785e98388bed' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='1cffbf51e63e634c746f741de50649bbbcbd9dbe1de363c9ecef64e278dba2b2' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='0a6bed6e9f21192a51f83977716466895706059afb880500ff1d0e751ada5237' ;; \
+        ppc64el) rustArch='powerpc64le-unknown-linux-gnu'; rustupSha256='079430f58ad4da1d1f4f5f2f0bd321422373213246a93b3ddb53dad627f5aa38' ;; \
+        s390x) rustArch='s390x-unknown-linux-gnu'; rustupSha256='e7f89da453c8ce5771c28279d1a01d5e83541d420695c74ec81a7ec5d287c51c' ;; \
         *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
     esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.26.0/${rustArch}/rustup-init"; \
+    url="https://static.rust-lang.org/rustup/archive/1.27.1/${rustArch}/rustup-init"; \
     wget "$url"; \
     echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
   "status": "error",
-  "message": "   Compiling leap v1.6.0 (example-empty-file)\nerror[E0425]: cannot find function `is_leap_year` in crate `leap`\n --> tests/leap.rs:2:22\n  |\n2 |     assert_eq!(leap::is_leap_year(year), expected);\n  |                      ^^^^^^^^^^^^ not found in `leap`\n\nerror[E0425]: cannot find function `is_leap_year` in crate `leap`\n  --> tests/leap.rs:94:31\n   |\n94 |         .filter(|&year| leap::is_leap_year(year) != (year % 4 == 0))\n   |                               ^^^^^^^^^^^^ not found in `leap`\n\nFor more information about this error, try `rustc --explain E0425`.\nerror: could not compile `leap` due to 2 previous errors\n
+  "message": "   Compiling leap v1.6.0 (example-empty-file)\nerror[E0425]: cannot find function `is_leap_year` in crate `leap`\n --> tests/leap.rs:2:22\n  |\n2 |     assert_eq!(leap::is_leap_year(year), expected);\n  |                      ^^^^^^^^^^^^ not found in `leap`\n\nerror[E0425]: cannot find function `is_leap_year` in crate `leap`\n  --> tests/leap.rs:94:31\n   |\n94 |         .filter(|&year| leap::is_leap_year(year) != (year % 4 == 0))\n   |                               ^^^^^^^^^^^^ not found in `leap`\n\nFor more information about this error, try `rustc --explain E0425`.\nerror: could not compile `leap` due to 2 previous errors\n"
 }


### PR DESCRIPTION
The breakage in https://github.com/exercism/rust-test-runner/pull/140 should be fixed now, but `cargo local-registry` still doesn't build because the updated dependencies require a more recent version of the Rust toolchain.