### PR TITLE
fix standard location of test file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,10 +70,10 @@ fn main() -> Result<()> {
 
     results_out.push_str(&deterministic_cargo_stderr);
 
-    // if there is no test file at the standard location (tests/<slug>.rs),
-    // pretend like the test file is empty
-    let test_file =
-        std::fs::read_to_string(format!("tests/{}.rs", cli_args.slug)).unwrap_or_default();
+    let snake_slug = cli_args.slug.replace('-', "_");
+    // if there is no test file at the standard location
+    // (tests/<snake_slug>.rs), pretend that the test file is empty
+    let test_file = std::fs::read_to_string(format!("tests/{snake_slug}.rs")).unwrap_or_default();
     let name_to_code = parse_test_code::parse_file(&test_file);
 
     let out = convert(


### PR DESCRIPTION
The test files were renamed to use snake case in:
https://github.com/exercism/rust/pull/2036