### PR TITLE
Rewrite Dockerfile to share layers with analyzer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ EOF
 # "nightly-slim", select "linux/amd64" and copy the manifest digest.
 # https://hub.docker.com/r/rustlang/rust/tags
 #
-FROM docker.io/rustlang/rust@sha256:3444fefbb69afbff45c0722c8045404c8e7f369c5202e916bd94f665b69f1b1c as rust-nightly-with-local-registry
+FROM docker.io/rustlang/rust@sha256:3444fefbb69afbff45c0722c8045404c8e7f369c5202e916bd94f665b69f1b1c AS rust-nightly-with-local-registry
 
 # add local registry
 COPY --from=build-local-registry /local-registry /local-registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,147 +1,74 @@
-# always build this using the latest stable release
-FROM rust:1.95.0 AS build-base
+############################# START SHARED LAYERS #############################
 
-ARG JQ_VERSION=1.6
-ARG JQ_URL=https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64
-# download jq
-RUN curl -L -o /usr/local/bin/jq "${JQ_URL}" \
-    && chmod +x /usr/local/bin/jq
+# IMPORTANT: This part of the build is shared between the test-runner and
+# analyzer. It takes a relatively large amount of space: 850 MB for the Rust
+# toolchain and 40 MB for the local cargo registry. Therefore, it's important
+# to keep this in sync between the two images. A slight mismatch in these layers
+# would lead to douple the storage requirement on Exercism's servers.
 
-# install cargo-local-registry dependencies
-RUN apt-get update && apt-get install -y gcc openssl cmake
+FROM rust:1.95.0 AS build-local-registry
+
+WORKDIR /work
+COPY local-registry/Cargo.toml .
+
+RUN <<EOF
+set -eux
+apt-get update
+apt-get install -y gcc openssl cmake
+cargo install --locked cargo-local-registry
+cargo generate-lockfile
+cargo local-registry sync Cargo.lock /local-registry
+EOF
+
+# As of April 2026, we need to use the nightly toolchain to get JSON test output
+# tracking issue: https://github.com/rust-lang/rust/issues/49359
+#
+# The official docker image for the nightly Rust toolchain is updated every
+# day. We don't want to invalidate the build cache that often, so we pin it
+# to a specific hash. To update, go to the following page, then navigate to
+# "nightly-slim", select "linux/amd64" and copy the manifest digest.
+# https://hub.docker.com/r/rustlang/rust/tags
+#
+FROM docker.io/rustlang/rust@sha256:3444fefbb69afbff45c0722c8045404c8e7f369c5202e916bd94f665b69f1b1c as rust-nightly-with-local-registry
+
+# add local registry
+COPY --from=build-local-registry /local-registry /local-registry
+RUN <<EOF
+echo "\
+[source.crates-io]
+registry = 'sparse+https://index.crates.io/'
+replace-with = 'local-registry'
+
+[source.local-registry]
+local-registry = '/local-registry'" >> $CARGO_HOME/config.toml
+EOF
+
+############################## END SHARED LAYERS ##############################
 
 
-FROM build-base AS build-rust-test-runner
+FROM rust:1.95.0 AS build
 
-RUN mkdir -p /rust-test-runner/src
-ENV wd=/rust-test-runner
-WORKDIR ${wd}
+WORKDIR /work
 COPY Cargo.* ./
 # for caching, we want to download and build all the dependencies before copying
 # any of the real source files. We therefore build an empty dummy library,
 # then remove it.
-RUN echo '// dummy file' > src/lib.rs
-RUN cargo build
-# now get rid of the stub and copy the real source files
-RUN rm src/lib.rs
+RUN <<EOF
+mkdir --parents src
+touch src/lib.rs
+cargo build --release
+rm src/lib.rs
+EOF
+# now build the real test-runner
 COPY src/* src/
-# build the executable
-RUN cargo build --release
+RUN touch src/lib.rs && cargo build --release
 
 
-FROM build-base AS build-cargo-local-registry
+FROM rust-nightly-with-local-registry
 
-# install cargo-local-registry
-RUN cargo install --locked cargo-local-registry
-# download popular crates to local registry
-WORKDIR /local-registry
-COPY local-registry/* ./
-RUN cargo generate-lockfile && cargo local-registry --sync Cargo.lock .
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 
-
-# As of Dec 2019, we need to use the nightly toolchain to get JSON test output
-# tracking issue: https://github.com/rust-lang/rust/issues/49359
-
-# Official docker images with pinned nightly versions are not provided, but we
-# want to pin the nightly version to avoid unnecessary cache misses. To achieve
-# this, we copy the source of the official rust docker images and replace the
-# version tag with a nightly one, pinned to a specific date.
-
-# official Dockerfile source: 
-# https://github.com/rust-lang/docker-rust/blob/master/stable/trixie/slim/Dockerfile
-
-################ start-copy-pasta ################
-
-FROM debian:trixie-slim
-
-LABEL org.opencontainers.image.source=https://github.com/rust-lang/docker-rust
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly-2026-04-17
-#                ~~~~~~~~^~~~~~~~~~
-#                 pin version here
-
-RUN set -eux; \
-    \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        ca-certificates \
-        gcc \
-        libc6-dev \
-        wget \
-        ; \
-    \
-    arch="$(dpkg --print-architecture)"; \
-    case "$arch" in \
-        'amd64') \
-            rustArch='x86_64-unknown-linux-gnu'; \
-            rustupSha256='20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c'; \
-            ;; \
-        'armhf') \
-            rustArch='armv7-unknown-linux-gnueabihf'; \
-            rustupSha256='3b8daab6cc3135f2cd4b12919559e6adaee73a2fbefb830fadf0405c20231d61'; \
-            ;; \
-        'arm64') \
-            rustArch='aarch64-unknown-linux-gnu'; \
-            rustupSha256='e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c'; \
-            ;; \
-        'i386') \
-            rustArch='i686-unknown-linux-gnu'; \
-            rustupSha256='a5db2c4b29d23e9b318b955dd0337d6b52e93933608469085c924e0d05b1df1f'; \
-            ;; \
-        'ppc64el') \
-            rustArch='powerpc64le-unknown-linux-gnu'; \
-            rustupSha256='acd89c42b47c93bd4266163a7b05d3f26287d5148413c0d47b2e8a7aa67c9dc0'; \
-            ;; \
-        's390x') \
-            rustArch='s390x-unknown-linux-gnu'; \
-            rustupSha256='726b7fd5d8805e73eab4a024a2889f8859d5a44e36041abac0a2436a52d42572'; \
-            ;; \
-        'riscv64') \
-            rustArch='riscv64gc-unknown-linux-gnu'; \
-            rustupSha256='09e64cc1b7a3e99adaa15dd2d46a3aad9d44d71041e2a96100d165c98a8fd7a7'; \
-            ;; \
-        *) \
-            echo >&2 "unsupported architecture: $arch"; \
-            exit 1; \
-            ;; \
-    esac; \
-    \
-    url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \
-    wget --progress=dot:giga "$url"; \
-    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-    \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
-    rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    \
-    apt-get remove -y --auto-remove \
-        wget \
-        ; \
-    rm -rf /var/lib/apt/lists/*; \
-    \
-    rustup --version; \
-    cargo --version; \
-    rustc --version;
-
-################ end-copy-pasta ################
-
-ENV wd=/opt/test-runner
-RUN mkdir -p ${wd}/bin
-WORKDIR ${wd}
-COPY --from=build-rust-test-runner /rust-test-runner/target/release/rust_test_runner bin
-COPY --from=build-base /usr/local/bin/jq /usr/local/bin
-COPY --from=build-cargo-local-registry /local-registry local-registry/
-# configure local-registry
-RUN echo '[source.crates-io]\n\
-    registry = "https://github.com/rust-lang/crates.io-index"\n\
-    replace-with = "local-registry"\n\
-    \n\
-    [source.local-registry]\n\
-    local-registry = "/opt/test-runner/local-registry/"\n' >> $CARGO_HOME/config.toml
-# set entrypoint
-COPY bin/run.sh bin
+WORKDIR /opt/test-runner
+COPY --from=build /work/target/release/rust_test_runner bin/
+COPY bin/run.sh bin/
 ENTRYPOINT ["bin/run.sh"]

--- a/local-registry/Cargo.toml
+++ b/local-registry/Cargo.toml
@@ -1,19 +1,11 @@
-[package]
-name = "dummy_package"
-version = "0.1.0"
-edition = "2021"
-
-[lib]
-path = "dummy.rs"
-
 # IMPORTANT: These dependencies should be kept in sync with the ones at
 # https://github.com/exercism/rust-analyzer/blob/main/local-registry/Cargo.toml
 #
 # Some crates are used by a large number of solutions. For example, when a crate
 # is required or already included in the exercise skeleton. For those crates,
-# we should *never* drop support for a given major version. We can continue to
-# support old and new versions by giving the old ones an alias. The downside is
-# an increase in the size of the local registry.
+# we should NEVER drop support for a given major version. They have been marked
+# with a "# pin" comment. We can continue to support old and new versions by
+# giving the old ones an alias. An example is the rand_09 crate below.
 # 
 [dependencies]
 anyhow = "1.0.102" # pin
@@ -119,3 +111,13 @@ unzip-n = "0.1.4"
 uuid = "1.23.1"
 voca_rs = "1.15.2"
 xvii = "0.4.0"
+
+# The following is only needed so the Cargo.toml defines a valid package.
+
+[package]
+name = "dummy_package"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "/dev/null"


### PR DESCRIPTION
The main goal of this is to bring the Dockerfiles of the test-runner and analyzer in sync, so they can share the big layers containing the Rust toolchain and local cargo registry.

Some incidental changes / improvements that were made:

* Use an official base image with a nightly Rust toolchain, but pinned to a specific hash. This avoids our cache being invalidated every day, without us needing to copy-paste the upstream build script.

* Make local-registry/Cargo.toml more readable for users by moving irrelevant stuff to the bottom. Exercises contain a link to this file, so that students can check themselves which crates are available.

* Use heredoc in the Dockerfile for better readability and to reduce the number of intermediate layers generated during a build.

The forum post discussing this:
https://forum.exercism.org/t/requesting-rust-docker-base-repository/48577