### PR TITLE
improve doctest code extraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,23 @@ where
                         // doctest block start, gather code lines
                         let mut code = String::new();
                         for (_, line) in lines.by_ref() {
-                            if line.starts_with("/// ```") {
+                            let Some(line) = line.strip_prefix("///") else {
+                                // doc comment ended before end of code block.
+                                // ignore this malformed doctest.
+                                continue 'find_doctest;
+                            };
+                            let Some(line) = line.strip_prefix(' ') else {
+                                // empty line inside code block.
+                                // skip, to keep test code short.
+                                continue;
+                            };
+                            if line.starts_with("```") {
                                 // doctest block end
                                 code.pop(); // trim trailing newline
                                 line_to_code.insert(i, code);
                                 continue 'find_doctest;
                             }
-                            code.push_str(line.trim_start_matches("/// "));
+                            code.push_str(line);
                             code.push('\n');
                         }
                         // no end of code block found. very strange. ignore.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,11 @@ where
                                 // skip, to keep test code short.
                                 continue;
                             };
+                            if line.starts_with('#') {
+                                // omit hidden lines, see:
+                                // https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#hiding-portions-of-the-example
+                                continue;
+                            }
                             if line.starts_with("```") {
                                 // doctest block end
                                 code.pop(); // trim trailing newline

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,14 @@ where
                             continue;
                         }
                         // doctest block start, gather code lines
-                        let mut code = String::new();
+                        let mut code = if line.contains("compile_fail") {
+                            // Doctests marked as "compile_fail" are otherwise
+                            // unmarked. Users could get confused by tests that
+                            // pass if their code doesn't even compile.
+                            String::from("// This code must not compile:\n")
+                        } else {
+                            String::new()
+                        };
                         for (_, line) in lines.by_ref() {
                             let Some(line) = line.strip_prefix("///") else {
                                 // doc comment ended before end of code block.

--- a/tests/example-doctests/expected_results.json
+++ b/tests/example-doctests/expected_results.json
@@ -5,13 +5,13 @@
   "tests": [
     {
       "name": "Comma separator",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// using only commas is invalid\nlet _hm: HashMap<_, _> = hashmap!('a', 1);",
+      "test_code": "// This code must not compile:\n// using only commas is invalid\nlet _hm: HashMap<_, _> = hashmap!('a', 1);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Double trailing commas",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single trailing comma is okay, but two is not\nlet _hm: HashMap<_, _> = hashmap!('a' => 2, ,);",
+      "test_code": "// This code must not compile:\n// a single trailing comma is okay, but two is not\nlet _hm: HashMap<_, _> = hashmap!('a' => 2, ,);",
       "status": "pass",
       "message": null
     },
@@ -23,19 +23,19 @@
     },
     {
       "name": "Leading comma",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// leading commas are not valid\nlet _hm: HashMap<_, _> = hashmap!(, 'a' => 2);",
+      "test_code": "// This code must not compile:\n// leading commas are not valid\nlet _hm: HashMap<_, _> = hashmap!(, 'a' => 2);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Missing argument",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// an argument should come between each pair of commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);",
+      "test_code": "// This code must not compile:\n// an argument should come between each pair of commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Missing comma",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// Key value pairs must be separated by commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);",
+      "test_code": "// This code must not compile:\n// Key value pairs must be separated by commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);",
       "status": "pass",
       "message": null
     },
@@ -53,13 +53,13 @@
     },
     {
       "name": "Only arrow",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single random arrow is not valid\nlet _hm: HashMap<(), ()> = hashmap!(=>);",
+      "test_code": "// This code must not compile:\n// a single random arrow is not valid\nlet _hm: HashMap<(), ()> = hashmap!(=>);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Only comma",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single random comma is not valid\nlet _hm: HashMap<(), ()> = hashmap!(,);",
+      "test_code": "// This code must not compile:\n// a single random comma is not valid\nlet _hm: HashMap<(), ()> = hashmap!(,);",
       "status": "pass",
       "message": null
     },
@@ -71,7 +71,7 @@
     },
     {
       "name": "Single argument",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single argument is invalid\nlet _hm: HashMap<_, _> = hashmap!('a');",
+      "test_code": "// This code must not compile:\n// a single argument is invalid\nlet _hm: HashMap<_, _> = hashmap!('a');",
       "status": "pass",
       "message": null
     },
@@ -89,7 +89,7 @@
     },
     {
       "name": "Trailing arrow",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a trailing => isn't valid either\nhashmap!('a' => 2, =>);",
+      "test_code": "// This code must not compile:\n// a trailing => isn't valid either\nhashmap!('a' => 2, =>);",
       "status": "pass",
       "message": null
     },
@@ -101,7 +101,7 @@
     },
     {
       "name": "Triple arguments",
-      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// three arguments are invalid\nhashmap!('a' => 1, 'b');",
+      "test_code": "// This code must not compile:\n// three arguments are invalid\nhashmap!('a' => 1, 'b');",
       "status": "pass",
       "message": null
     },

--- a/tests/example-doctests/expected_results.json
+++ b/tests/example-doctests/expected_results.json
@@ -5,13 +5,13 @@
   "tests": [
     {
       "name": "Comma separator",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// using only commas is invalid\nlet _hm: HashMap<_, _> = hashmap!('a', 1);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// using only commas is invalid\nlet _hm: HashMap<_, _> = hashmap!('a', 1);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Double trailing commas",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// a single trailing comma is okay, but two is not\nlet _hm: HashMap<_, _> = hashmap!('a' => 2, ,);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single trailing comma is okay, but two is not\nlet _hm: HashMap<_, _> = hashmap!('a' => 2, ,);",
       "status": "pass",
       "message": null
     },
@@ -23,19 +23,19 @@
     },
     {
       "name": "Leading comma",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// leading commas are not valid\nlet _hm: HashMap<_, _> = hashmap!(, 'a' => 2);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// leading commas are not valid\nlet _hm: HashMap<_, _> = hashmap!(, 'a' => 2);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Missing argument",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// an argument should come between each pair of commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// an argument should come between each pair of commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Missing comma",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// Key value pairs must be separated by commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// Key value pairs must be separated by commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);",
       "status": "pass",
       "message": null
     },
@@ -53,13 +53,13 @@
     },
     {
       "name": "Only arrow",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// a single random arrow is not valid\nlet _hm: HashMap<(), ()> = hashmap!(=>);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single random arrow is not valid\nlet _hm: HashMap<(), ()> = hashmap!(=>);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Only comma",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// a single random comma is not valid\nlet _hm: HashMap<(), ()> = hashmap!(,);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single random comma is not valid\nlet _hm: HashMap<(), ()> = hashmap!(,);",
       "status": "pass",
       "message": null
     },
@@ -71,7 +71,7 @@
     },
     {
       "name": "Single argument",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// a single argument is invalid\nlet _hm: HashMap<_, _> = hashmap!('a');",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single argument is invalid\nlet _hm: HashMap<_, _> = hashmap!('a');",
       "status": "pass",
       "message": null
     },
@@ -89,7 +89,7 @@
     },
     {
       "name": "Trailing arrow",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// a trailing => isn't valid either\nhashmap!('a' => 2, =>);",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a trailing => isn't valid either\nhashmap!('a' => 2, =>);",
       "status": "pass",
       "message": null
     },
@@ -101,7 +101,7 @@
     },
     {
       "name": "Triple arguments",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n///\n// three arguments are invalid\nhashmap!('a' => 1, 'b');",
+      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// three arguments are invalid\nhashmap!('a' => 1, 'b');",
       "status": "pass",
       "message": null
     },

--- a/tests/example-doctests/expected_results.json
+++ b/tests/example-doctests/expected_results.json
@@ -5,13 +5,13 @@
   "tests": [
     {
       "name": "Comma separator",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// using only commas is invalid\nlet _hm: HashMap<_, _> = hashmap!('a', 1);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// using only commas is invalid\nlet _hm: HashMap<_, _> = hashmap!('a', 1);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Double trailing commas",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single trailing comma is okay, but two is not\nlet _hm: HashMap<_, _> = hashmap!('a' => 2, ,);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single trailing comma is okay, but two is not\nlet _hm: HashMap<_, _> = hashmap!('a' => 2, ,);",
       "status": "pass",
       "message": null
     },
@@ -23,19 +23,19 @@
     },
     {
       "name": "Leading comma",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// leading commas are not valid\nlet _hm: HashMap<_, _> = hashmap!(, 'a' => 2);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// leading commas are not valid\nlet _hm: HashMap<_, _> = hashmap!(, 'a' => 2);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Missing argument",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// an argument should come between each pair of commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// an argument should come between each pair of commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Missing comma",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// Key value pairs must be separated by commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// Key value pairs must be separated by commas\nlet _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);",
       "status": "pass",
       "message": null
     },
@@ -53,13 +53,13 @@
     },
     {
       "name": "Only arrow",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single random arrow is not valid\nlet _hm: HashMap<(), ()> = hashmap!(=>);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single random arrow is not valid\nlet _hm: HashMap<(), ()> = hashmap!(=>);",
       "status": "pass",
       "message": null
     },
     {
       "name": "Only comma",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single random comma is not valid\nlet _hm: HashMap<(), ()> = hashmap!(,);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single random comma is not valid\nlet _hm: HashMap<(), ()> = hashmap!(,);",
       "status": "pass",
       "message": null
     },
@@ -71,7 +71,7 @@
     },
     {
       "name": "Single argument",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a single argument is invalid\nlet _hm: HashMap<_, _> = hashmap!('a');",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a single argument is invalid\nlet _hm: HashMap<_, _> = hashmap!('a');",
       "status": "pass",
       "message": null
     },
@@ -89,7 +89,7 @@
     },
     {
       "name": "Trailing arrow",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// a trailing => isn't valid either\nhashmap!('a' => 2, =>);",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// a trailing => isn't valid either\nhashmap!('a' => 2, =>);",
       "status": "pass",
       "message": null
     },
@@ -101,7 +101,7 @@
     },
     {
       "name": "Triple arguments",
-      "test_code": "use macros::hashmap;\nuse std::collections::HashMap;\n// three arguments are invalid\nhashmap!('a' => 1, 'b');",
+      "test_code": "// This code must not compile:\nuse macros::hashmap;\nuse std::collections::HashMap;\n// three arguments are invalid\nhashmap!('a' => 1, 'b');",
       "status": "pass",
       "message": null
     },
@@ -113,7 +113,7 @@
     },
     {
       "name": "Whatever",
-      "test_code": "invalid rust syntax",
+      "test_code": "// This code must not compile:\ninvalid rust syntax",
       "status": "pass",
       "message": null
     }

--- a/tests/example-doctests/src/compile_fail_tests.rs
+++ b/tests/example-doctests/src/compile_fail_tests.rs
@@ -1,8 +1,8 @@
 // To activate a doctest locally, remove ",ignore" from the code block.
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // using only commas is invalid
 /// let _hm: HashMap<_, _> = hashmap!('a', 1);
@@ -10,8 +10,8 @@
 const _COMMA_SEPARATOR: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single trailing comma is okay, but two is not
 /// let _hm: HashMap<_, _> = hashmap!('a' => 2, ,);
@@ -19,8 +19,8 @@ const _COMMA_SEPARATOR: () = ();
 const _DOUBLE_TRAILING_COMMAS: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single random comma is not valid
 /// let _hm: HashMap<(), ()> = hashmap!(,);
@@ -28,8 +28,8 @@ const _DOUBLE_TRAILING_COMMAS: () = ();
 const _ONLY_COMMA: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single argument is invalid
 /// let _hm: HashMap<_, _> = hashmap!('a');
@@ -37,8 +37,8 @@ const _ONLY_COMMA: () = ();
 const _SINGLE_ARGUMENT: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // three arguments are invalid
 /// hashmap!('a' => 1, 'b');
@@ -46,8 +46,8 @@ const _SINGLE_ARGUMENT: () = ();
 const _TRIPLE_ARGUMENTS: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a single random arrow is not valid
 /// let _hm: HashMap<(), ()> = hashmap!(=>);
@@ -55,8 +55,8 @@ const _TRIPLE_ARGUMENTS: () = ();
 const _ONLY_ARROW: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // a trailing => isn't valid either
 /// hashmap!('a' => 2, =>);
@@ -64,8 +64,8 @@ const _ONLY_ARROW: () = ();
 const _TRAILING_ARROW: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // leading commas are not valid
 /// let _hm: HashMap<_, _> = hashmap!(, 'a' => 2);
@@ -73,8 +73,8 @@ const _TRAILING_ARROW: () = ();
 const _LEADING_COMMA: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // Key value pairs must be separated by commas
 /// let _hm: HashMap<_, _> = hashmap!('a' => 1 'b' => 2);
@@ -82,8 +82,8 @@ const _LEADING_COMMA: () = ();
 const _MISSING_COMMA: () = ();
 
 /// ```compile_fail,ignore
-/// use macros::hashmap;
-/// use std::collections::HashMap;
+/// # use macros::hashmap;
+/// # use std::collections::HashMap;
 ///
 /// // an argument should come between each pair of commas
 /// let _hm: HashMap<_, _> = hashmap!('a' => 1, , 'b' => 2);


### PR DESCRIPTION
* omit empty lines from doctests
* explain "compile_fail" doctests to users
* omit hidden lines from doctests like rustdoc